### PR TITLE
Allow sending of file as attachment or as inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install
 
 With composer add to your "require" section: 
 
-    composer require diversen/http-send-file
+    composer require shemgp/http-send-file
 
 Usage example: 
 
@@ -80,6 +80,20 @@ Without sending content-disposition header:
 // 2. param = false
 try {
     $s->send($file, false);
+} catch (\Exception $e) {
+    echo $e->getMessage();
+}
+
+~~~
+
+Send file as inline: 
+
+~~~php
+
+// Send as inline
+// 3. param = false
+try {
+    $s->send($file, true, false);
 } catch (\Exception $e) {
     echo $e->getMessage();
 }

--- a/README.md
+++ b/README.md
@@ -110,4 +110,4 @@ The process is nicely explained here:
 
 <http://www.media-division.com/the-right-way-to-handle-file-downloads-in-php/>
 
-MIT © [Dennis Iversen](https://github.com/diversen)
+MIT © [Dennis Iversen](https://github.com/diversen). [Shem Pasamba](https://github.com/shemgp)

--- a/README.md
+++ b/README.md
@@ -110,4 +110,4 @@ The process is nicely explained here:
 
 <http://www.media-division.com/the-right-way-to-handle-file-downloads-in-php/>
 
-MIT © [Dennis Iversen](https://github.com/diversen). [Shem Pasamba](https://github.com/shemgp)
+MIT © [Dennis Iversen](https://github.com/diversen), [Shem Pasamba](https://github.com/shemgp)

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "diversen/http-send-file",
+    "name": "shemgp/http-send-file",
     "type": "library",
     "description": "Sends a file to a client, with support for (multiple) range requests. It is also able to throttle the download.",
     "homepage": "http://github.com/diversen/http-send-file",
@@ -11,11 +11,17 @@
             "email": "dennis.iversen@gmail.com",
             "homepage": "http://www.coscms.org/",
             "role": "Developer"
+        },
+        {
+            "name": "Shem Pasamba",
+            "email": "shemgp@gmail.com",
+            "homepage": "http://www.aiias.edu/",
+            "role": "Developer"
         }
     ],
     "autoload": {
         "psr-4": {
-            "diversen\\": ""
+            "shemgp\\": ""
         }
     },
     "extra": {

--- a/sendfile.php
+++ b/sendfile.php
@@ -76,7 +76,7 @@ class sendfile
      * @param boolean $withDisposition
      * @throws Exception
      */
-    public function send($file_path, $withDisposition=TRUE) {
+    public function send($file_path, $withDisposition=TRUE, $asAttachment=TRUE) {
         
         if (!is_readable($file_path)) {
             throw new \Exception('File not found or inaccessible!');
@@ -90,6 +90,10 @@ class sendfile
         if (!$this->type) {
             $this->type = $this->getContentType($file_path);
         }
+        
+        $contentDisposition = 'attachment';
+        if ($asAttachment === FALSE)
+            $contentDisposition = 'inline';
 
         //turn off output buffering to decrease cpu usage
         $this->cleanAll();
@@ -101,7 +105,7 @@ class sendfile
 
         header('Content-Type: ' . $this->type);
         if ($withDisposition) {
-            header('Content-Disposition: attachment; filename="' . $this->disposition . '"');
+            header('Content-Disposition: ' . $contentDisposition . '; filename="' . $this->disposition . '"');
         }
         header('Accept-Ranges: bytes');
 

--- a/sendfile.php
+++ b/sendfile.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace diversen;
+namespace shemgp;
 
 /**
  * Sends a file to a client, with support for (multiple) range requests. 
@@ -76,7 +76,7 @@ class sendfile
      * @param boolean $withDisposition
      * @throws Exception
      */
-    public function send($file_path, $withDisposition=TRUE, $asAttachment=TRUE) {
+    public function send($file_path, $withDisposition=TRUE, $asDownload = TRUE) {
         
         if (!is_readable($file_path)) {
             throw new \Exception('File not found or inaccessible!');
@@ -90,10 +90,6 @@ class sendfile
         if (!$this->type) {
             $this->type = $this->getContentType($file_path);
         }
-        
-        $contentDisposition = 'attachment';
-        if ($asAttachment === FALSE)
-            $contentDisposition = 'inline';
 
         //turn off output buffering to decrease cpu usage
         $this->cleanAll();
@@ -102,6 +98,10 @@ class sendfile
         if (ini_get('zlib.output_compression')) {
             ini_set('zlib.output_compression', 'Off');
         }
+
+	$contentDisposition = 'download';
+	if (!$asDownload)
+		$contentDisposition = 'inline';
 
         header('Content-Type: ' . $this->type);
         if ($withDisposition) {

--- a/sendfile.php
+++ b/sendfile.php
@@ -16,10 +16,11 @@ class sendfile
     private $disposition = false;
     
     /**
-     * throttle speed in secounds
+     * throttle speed in seconds
+     * Defaults to no throttle
      * @var float $sec
      */
-    private $sec = 0.1;
+    private $sec = 0;
     
     /**
      * bytes per $sec


### PR DESCRIPTION
Sometimes it's needed to view a video online so a switch for 'attachment' or 'inline' is needed.